### PR TITLE
Use pebble for services

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -14,10 +14,12 @@ license: Apache-2.0
 # └── etc
 #     └── alertmanager
 #         └── alertmanager.yml
-entrypoint: [bin/alertmanager]
-cmd: [--config.file=/etc/alertmanager/alertmanager.yml, --storage.path=/alertmanager]
-env:
-  - PATH: /bin
+
+services:
+  alertmanager:
+    command: /bin/alertmanager --config.file=/etc/alertmanager/alertmanager.yml --storage.path=/alertmanager
+    override: replace
+    startup: enabled
 platforms:
   amd64:
 parts:


### PR DESCRIPTION
`cmd` and `env` can no no longer be used. Pebble is integrated. Set up a default service.