### PR TITLE
add deb security manifest

### DIFF
--- a/0.25.0/rockcraft.yaml
+++ b/0.25.0/rockcraft.yaml
@@ -6,7 +6,6 @@ base: ubuntu:22.04
 license: Apache-2.0
 # Replicate the tree structure of the original image
 # https://github.com/prometheus/alertmanager/blob/main/Dockerfile
-
 # /
 # ├── bin
 # │   ├── alertmanager
@@ -14,7 +13,6 @@ license: Apache-2.0
 # └── etc
 #     └── alertmanager
 #         └── alertmanager.yml
-
 services:
   alertmanager:
     command: /bin/alertmanager --config.file=/etc/alertmanager/alertmanager.yml --storage.path=/alertmanager
@@ -61,3 +59,13 @@ parts:
   ca-certs:
     plugin: nil
     stage-packages: [ca-certificates]
+  # The security manifest is required when .deb packages are added to the ROCK
+  deb-security-manifest:
+    plugin: nil
+    after:
+      - alertmanager
+      - ca-certs
+    override-prime: |
+      set -x
+      mkdir -p $CRAFT_PRIME/usr/share/rocks/
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query --admindir=$CRAFT_PRIME/var/lib/dpkg/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > $CRAFT_PRIME/usr/share/rocks/dpkg.query

--- a/0.26.0/rockcraft.yaml
+++ b/0.26.0/rockcraft.yaml
@@ -6,7 +6,6 @@ base: ubuntu:22.04
 license: Apache-2.0
 # Replicate the tree structure of the original image
 # https://github.com/prometheus/alertmanager/blob/main/Dockerfile
-
 # /
 # ├── bin
 # │   ├── alertmanager
@@ -60,3 +59,13 @@ parts:
   ca-certs:
     plugin: nil
     stage-packages: [ca-certificates]
+  # The security manifest is required when .deb packages are added to the ROCK
+  deb-security-manifest:
+    plugin: nil
+    after:
+      - alertmanager
+      - ca-certs
+    override-prime: |
+      set -x
+      mkdir -p $CRAFT_PRIME/usr/share/rocks/
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query --admindir=$CRAFT_PRIME/var/lib/dpkg/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > $CRAFT_PRIME/usr/share/rocks/dpkg.query


### PR DESCRIPTION
As specified in the OCI Factory's [image maintainer agreement](https://github.com/canonical/oci-factory/blob/main/IMAGE_MAINTAINER_AGREEMENT.md#enable-security-monitoring), ROCKs that include additional deb packages (in our case, `ca-certificates`) must render a security manifest; the purpose is to allow the security team to notify us in case of security issues with those packages.