### PR TITLE
Use blackhole receiver in default config file

### DIFF
--- a/0.25.0/alertmanager.yml
+++ b/0.25.0/alertmanager.yml
@@ -6,11 +6,9 @@ route:
   group_wait: 30s
   group_interval: 5m
   repeat_interval: 1h
-  receiver: 'web.hook'
+  receiver: 'blackhole'
 receivers:
-  - name: 'web.hook'
-    webhook_configs:
-      - url: 'http://127.0.0.1:5001/'
+  - name: 'blackhole'
 inhibit_rules:
   - source_match:
       severity: 'critical'

--- a/0.26.0/alertmanager.yml
+++ b/0.26.0/alertmanager.yml
@@ -6,11 +6,9 @@ route:
   group_wait: 30s
   group_interval: 5m
   repeat_interval: 1h
-  receiver: 'web.hook'
+  receiver: 'blackhole'
 receivers:
-  - name: 'web.hook'
-    webhook_configs:
-      - url: 'http://127.0.0.1:5001/'
+  - name: 'blackhole'
 inhibit_rules:
   - source_match:
       severity: 'critical'

--- a/0.27.0/alertmanager.yml
+++ b/0.27.0/alertmanager.yml
@@ -6,11 +6,9 @@ route:
   group_wait: 30s
   group_interval: 5m
   repeat_interval: 1h
-  receiver: 'web.hook'
+  receiver: 'blackhole'
 receivers:
-  - name: 'web.hook'
-    webhook_configs:
-      - url: 'http://127.0.0.1:5001/'
+  - name: 'blackhole'
 inhibit_rules:
   - source_match:
       severity: 'critical'


### PR DESCRIPTION
## Issue
See https://github.com/canonical/alertmanager-k8s-operator/issues/237.


## Solution
Remove receiver address, turning it into a "blackhole receiver".
In tandem with: https://github.com/canonical/alertmanager-k8s-operator/pull/238.
