### PR TITLE
feat: add alertmanager 0.32.0

### DIFF
--- a/0.32.0/alertmanager.yml
+++ b/0.32.0/alertmanager.yml
@@ -1,0 +1,17 @@
+# Dummy config file. Alertmanager won't start without one.
+# Source: https://github.com/prometheus/alertmanager/releases/download/v0.24.0/alertmanager-0.24.0.linux-amd64.tar.gz
+
+route:
+  group_by: ['alertname']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 1h
+  receiver: 'blackhole'
+receivers:
+  - name: 'blackhole'
+inhibit_rules:
+  - source_match:
+      severity: 'critical'
+    target_match:
+      severity: 'warning'
+    equal: ['alertname', 'dev', 'instance']

--- a/0.32.0/rockcraft.yaml
+++ b/0.32.0/rockcraft.yaml
@@ -1,0 +1,71 @@
+name: alertmanager
+summary: Prometheus alertmanager in a ROCK.
+description: Alertmanager handles alerts sent by client applications such as the Prometheus server.
+version: "0.32.0"
+base: ubuntu@24.04
+license: Apache-2.0
+# Replicate the tree structure of the original image
+# https://github.com/prometheus/alertmanager/blob/main/Dockerfile
+# /
+# ├── bin
+# │   ├── alertmanager
+# │   └── amtool
+# └── etc
+#     └── alertmanager
+#         └── alertmanager.yml
+services:
+  alertmanager:
+    command: /bin/alertmanager --config.file=/etc/alertmanager/alertmanager.yml --storage.path=/alertmanager
+    override: replace
+    startup: enabled
+platforms:
+  amd64:
+parts:
+  alertmanager:
+    plugin: go
+    source: https://github.com/prometheus/alertmanager.git
+    source-type: git
+    source-tag: "v0.32.0"
+    # Override until this issue is fixed: https://github.com/canonical/rockcraft/issues/21
+    build-snaps:
+      - go/1.25/candidate
+    stage-packages:
+      - ca-certificates
+    override-build: |
+      set -x
+      REVISION=$(git rev-parse --short HEAD)
+      BRANCH=$(git rev-parse --abbrev-ref HEAD)
+      go build \
+        -ldflags="-X github.com/prometheus/common/version.Version=$(cat ./VERSION) -X github.com/prometheus/common/version.Revision=${REVISION} -X github.com/prometheus/common/version.Branch=${BRANCH} -X github.com/prometheus/common/version.BuildUser=$(whoami)@$(hostname) -X github.com/prometheus/common/version.BuildDate=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+        -o bin/alertmanager \
+        ./cmd/alertmanager
+      go build \
+        -ldflags="-X github.com/prometheus/common/version.Version=$(cat ./VERSION) -X github.com/prometheus/common/version.Revision=${REVISION} -X github.com/prometheus/common/version.Branch=${BRANCH} -X github.com/prometheus/common/version.BuildUser=$(whoami)@$(hostname) -X github.com/prometheus/common/version.BuildDate=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+        -o bin/amtool \
+        ./cmd/amtool
+        install -D -m755 bin/alertmanager ${CRAFT_PART_INSTALL}/bin/alertmanager
+        install -D -m755 bin/amtool ${CRAFT_PART_INSTALL}/bin/amtool
+    stage:
+      - bin/alertmanager
+      - bin/amtool
+  default-config:
+    plugin: dump
+    source: .
+    organize:
+      alertmanager.yml: etc/alertmanager/alertmanager.yml
+    stage:
+      - etc/alertmanager/alertmanager.yml
+  # We moved this here because: https://github.com/canonical/rockcraft/issues/343
+  ca-certs:
+    plugin: nil
+    overlay-packages: [ca-certificates]
+  # The security manifest is required when .deb packages are added to the ROCK
+  deb-security-manifest:
+    plugin: nil
+    after:
+      - alertmanager
+      - ca-certs
+    override-prime: |
+      set -x
+      mkdir -p $CRAFT_PRIME/usr/share/rocks/
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query --admindir=$CRAFT_PRIME/var/lib/dpkg/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > $CRAFT_PRIME/usr/share/rocks/dpkg.query

--- a/0.32.0/rockcraft.yaml
+++ b/0.32.0/rockcraft.yaml
@@ -29,10 +29,13 @@ parts:
     # Override until this issue is fixed: https://github.com/canonical/rockcraft/issues/21
     build-snaps:
       - go/1.25/candidate
+      - node/24/stable
     stage-packages:
       - ca-certificates
     override-build: |
       set -x
+      # Build the frontend UI (required since v0.32.0 uses //go:embed app/dist)
+      cd ui/app && npm ci && npm run build && cd ../..
       REVISION=$(git rev-parse --short HEAD)
       BRANCH=$(git rev-parse --abbrev-ref HEAD)
       go build \

--- a/0.32.0/spread/.extension
+++ b/0.32.0/spread/.extension
@@ -1,0 +1,195 @@
+#!/bin/bash
+
+usage() {
+    echo "usage: $(basename "$0") [command]"
+    echo "valid commands:"
+    echo "    allocate              Create a backend instance to run tests on"
+    echo "    discard               Destroy a backend instance used to run tests"
+    echo "    backend-prepare       Set up the system to run tests"
+    echo "    backend-restore       Restore the system after the tests ran"
+    echo "    backend-prepare-each  Prepare the system before each test"
+    echo "    backend-restore-each  Restore the system after each test run"
+}
+
+prepare() {
+    case "$SPREAD_SYSTEM" in
+    fedora*)
+        dnf update -y
+        dnf install -y snapd
+        while ! snap install snapd; do
+            echo "waiting for snapd..."
+            sleep 2
+        done
+        ;;
+    debian*)
+        apt update
+        apt install -y snapd
+        while ! snap install snapd; do
+            echo "waiting for snapd..."
+            sleep 2
+        done
+        ;;
+    ubuntu*)
+        apt update
+        ;;
+    esac
+
+    snap wait system seed.loaded
+    snap refresh --hold
+
+    if systemctl is-enabled unattended-upgrades.service; then
+        systemctl stop unattended-upgrades.service
+        systemctl mask unattended-upgrades.service
+    fi
+}
+
+restore() {
+    case "$SPREAD_SYSTEM" in
+    ubuntu* | debian*)
+        apt autoremove -y --purge
+        ;;
+    esac
+
+    rm -Rf "$PROJECT_PATH"
+    mkdir -p "$PROJECT_PATH"
+}
+
+prepare_each() {
+    true
+}
+
+restore_each() {
+    true
+}
+
+allocate_lxdvm() {
+    name=$(echo "$SPREAD_SYSTEM" | tr '[:punct:]' -)
+    system=$(echo "$SPREAD_SYSTEM" | tr / -)
+    if [[ "$system" =~ ^ubuntu- ]]; then
+        image="ubuntu:${system#ubuntu-}"
+    else
+        image="images:$(echo "$system" | tr - /)"
+    fi
+
+    VM_NAME="${VM_NAME:-spread-${name}-${RANDOM}}"
+    DISK="${DISK:-20}"
+    CPU="${CPU:-4}"
+    MEM="${MEM:-8}"
+
+    lxc launch --vm \
+        "${image}" \
+        "${VM_NAME}" \
+        -c limits.cpu="${CPU}" \
+        -c limits.memory="${MEM}GiB" \
+        -d root,size="${DISK}GiB"
+
+    while ! lxc exec "${VM_NAME}" -- true &>/dev/null; do sleep 0.5; done
+    lxc exec "${VM_NAME}" -- sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
+    lxc exec "${VM_NAME}" -- bash -c "if [ -d /etc/ssh/sshd_config.d ]; then echo -e 'PermitRootLogin yes\nPasswordAuthentication yes' > /etc/ssh/sshd_config.d/00-spread.conf; fi"
+    lxc exec "${VM_NAME}" -- bash -c "echo root:${SPREAD_PASSWORD} | sudo chpasswd || true"
+
+    # Print the instance address to stdout
+    ADDR=""
+    while [ -z "$ADDR" ]; do ADDR=$(lxc ls -f csv | grep "^${VM_NAME}" | cut -d"," -f3 | cut -d" " -f1); done
+    echo "$ADDR" 1>&3
+}
+
+discard_lxdvm() {
+    instance_name="$(lxc ls -f csv | sed ':a;N;$!ba;s/(docker0)\n/(docker0) /' | grep "$SPREAD_SYSTEM_ADDRESS " | cut -f1 -d",")"
+    lxc delete -f "$instance_name"
+}
+
+allocate_ci() {
+    if [ -z "$CI" ]; then
+        echo "This backend is intended to be used only in CI systems."
+        exit 1
+    fi
+    sudo sed -i 's/^\s*#\?\s*\(PermitRootLogin\|PasswordAuthentication\)\>.*/\1 yes/' /etc/ssh/sshd_config
+    if [ -d /etc/ssh/sshd_config.d ]; then echo -e 'PermitRootLogin yes\nPasswordAuthentication yes' | sudo tee /etc/ssh/sshd_config.d/00-spread.conf; fi
+    sudo systemctl daemon-reload
+    sudo systemctl restart ssh
+
+    echo "root:${SPREAD_PASSWORD}" | sudo chpasswd || true
+
+    # Print the instance address to stdout
+    echo localhost >&3
+}
+
+discard_ci() {
+    true
+}
+
+allocate() {
+    exec 3>&1
+    exec 1>&2
+
+    case "$1" in
+    lxd-vm)
+        allocate_lxdvm
+        ;;
+    ci)
+        allocate_ci
+        ;;
+    *)
+        echo "unsupported backend $1" 2>&1
+        ;;
+    esac
+}
+
+discard() {
+    case "$1" in
+    lxd-vm)
+        discard_lxdvm
+        ;;
+    ci)
+        discard_ci
+        ;;
+    *)
+        echo "unsupported backend $1" 2>&1
+        ;;
+    esac
+}
+
+set -e
+
+while getopts "" o; do
+    case "${o}" in
+    *)
+        usage
+        exit 1
+        ;;
+    esac
+done
+shift $((OPTIND - 1))
+
+CMD="$1"
+PARM="$2"
+
+if [ -z "$CMD" ]; then
+    usage
+    exit 0
+fi
+
+case "$CMD" in
+allocate)
+    allocate "$PARM"
+    ;;
+discard)
+    discard "$PARM"
+    ;;
+backend-prepare)
+    prepare
+    ;;
+backend-restore)
+    restore
+    ;;
+backend-prepare-each)
+    prepare_each
+    ;;
+backend-restore-each)
+    restore_each
+    ;;
+*)
+    echo "unknown command $CMD" >&2
+    ;;
+esac

--- a/0.32.0/spread/general/ready/task.yaml
+++ b/0.32.0/spread/general/ready/task.yaml
@@ -1,0 +1,7 @@
+summary: Run goss tests
+
+environment:
+  GOSS_FILE: "../../../goss.yaml"
+
+execute: |
+  dgoss run rockcraft-test:latest

--- a/0.32.0/spread/general/test/task.yaml
+++ b/0.32.0/spread/general/test/task.yaml
@@ -1,0 +1,8 @@
+summary: Run goss tests
+
+environment:
+  GOSS_FILE: "../../../goss.yaml"
+
+execute: |
+  dgoss run rockcraft-test:latest
+


### PR DESCRIPTION
Alertmanager 0.32.0 doesn't build out-of-the box because of some upstream changes.

## Root Cause

Alertmanager **v0.32.0** changed how UI assets are embedded. Previously (v0.31.1), the Go code imported pre-built assets from a Go package (`asset.Assets`). In v0.32.0, `ui/web.go` uses `//go:embed app/dist` to embed the frontend directly — meaning the Elm/Vite frontend in `ui/app/` **must be built first** to produce the `dist/` directory before `go build` runs.

The `rockcraft.yaml` is missing:
1. **`node` snap** as a build dependency (needed for `npm`)
2. **Frontend build step** (`npm ci && npm run build` in `ui/app/`) before the Go compilation

## Suggested Fix

Two changes to `0.32.0/rockcraft.yaml`:
- Add `node/24/stable` to `build-snaps`
- Add `cd ui/app && npm ci && npm run build && cd ../..` before the `go build` commands