### PR TITLE
chore: bump base to ubuntu@26.04

### DIFF
--- a/0.31.1/rockcraft.yaml
+++ b/0.31.1/rockcraft.yaml
@@ -2,7 +2,7 @@ name: alertmanager
 summary: Prometheus alertmanager in a ROCK.
 description: Alertmanager handles alerts sent by client applications such as the Prometheus server.
 version: "0.31.1"
-base: ubuntu@24.04
+base: ubuntu@26.04
 license: Apache-2.0
 # Replicate the tree structure of the original image
 # https://github.com/prometheus/alertmanager/blob/main/Dockerfile

--- a/0.31.1/rockcraft.yaml
+++ b/0.31.1/rockcraft.yaml
@@ -43,11 +43,11 @@ parts:
         -ldflags="-X github.com/prometheus/common/version.Version=$(cat ./VERSION) -X github.com/prometheus/common/version.Revision=${REVISION} -X github.com/prometheus/common/version.Branch=${BRANCH} -X github.com/prometheus/common/version.BuildUser=$(whoami)@$(hostname) -X github.com/prometheus/common/version.BuildDate=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
         -o bin/amtool \
         ./cmd/amtool
-        install -D -m755 bin/alertmanager ${CRAFT_PART_INSTALL}/bin/alertmanager
-        install -D -m755 bin/amtool ${CRAFT_PART_INSTALL}/bin/amtool
+        install -D -m755 bin/alertmanager ${CRAFT_PART_INSTALL}/usr/bin/alertmanager
+        install -D -m755 bin/amtool ${CRAFT_PART_INSTALL}/usr/bin/amtool
     stage:
-      - bin/alertmanager
-      - bin/amtool
+      - usr/bin/alertmanager
+      - usr/bin/amtool
   default-config:
     plugin: dump
     source: .

--- a/0.32.0/rockcraft.yaml
+++ b/0.32.0/rockcraft.yaml
@@ -46,11 +46,11 @@ parts:
         -ldflags="-X github.com/prometheus/common/version.Version=$(cat ./VERSION) -X github.com/prometheus/common/version.Revision=${REVISION} -X github.com/prometheus/common/version.Branch=${BRANCH} -X github.com/prometheus/common/version.BuildUser=$(whoami)@$(hostname) -X github.com/prometheus/common/version.BuildDate=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
         -o bin/amtool \
         ./cmd/amtool
-        install -D -m755 bin/alertmanager ${CRAFT_PART_INSTALL}/bin/alertmanager
-        install -D -m755 bin/amtool ${CRAFT_PART_INSTALL}/bin/amtool
+        install -D -m755 bin/alertmanager ${CRAFT_PART_INSTALL}/usr/bin/alertmanager
+        install -D -m755 bin/amtool ${CRAFT_PART_INSTALL}/usr/bin/amtool
     stage:
-      - bin/alertmanager
-      - bin/amtool
+      - usr/bin/alertmanager
+      - usr/bin/amtool
   default-config:
     plugin: dump
     source: .

--- a/0.32.0/rockcraft.yaml
+++ b/0.32.0/rockcraft.yaml
@@ -2,7 +2,7 @@ name: alertmanager
 summary: Prometheus alertmanager in a ROCK.
 description: Alertmanager handles alerts sent by client applications such as the Prometheus server.
 version: "0.32.0"
-base: ubuntu@24.04
+base: ubuntu@26.04
 license: Apache-2.0
 # Replicate the tree structure of the original image
 # https://github.com/prometheus/alertmanager/blob/main/Dockerfile

--- a/0.32.1/rockcraft.yaml
+++ b/0.32.1/rockcraft.yaml
@@ -2,7 +2,7 @@ name: alertmanager
 summary: Prometheus alertmanager in a ROCK.
 description: Alertmanager handles alerts sent by client applications such as the Prometheus server.
 version: "0.32.1"
-base: ubuntu@24.04
+base: ubuntu@26.04
 license: Apache-2.0
 # Replicate the tree structure of the original image
 # https://github.com/prometheus/alertmanager/blob/main/Dockerfile

--- a/0.32.1/rockcraft.yaml
+++ b/0.32.1/rockcraft.yaml
@@ -46,11 +46,11 @@ parts:
         -ldflags="-X github.com/prometheus/common/version.Version=$(cat ./VERSION) -X github.com/prometheus/common/version.Revision=${REVISION} -X github.com/prometheus/common/version.Branch=${BRANCH} -X github.com/prometheus/common/version.BuildUser=$(whoami)@$(hostname) -X github.com/prometheus/common/version.BuildDate=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
         -o bin/amtool \
         ./cmd/amtool
-        install -D -m755 bin/alertmanager ${CRAFT_PART_INSTALL}/bin/alertmanager
-        install -D -m755 bin/amtool ${CRAFT_PART_INSTALL}/bin/amtool
+        install -D -m755 bin/alertmanager ${CRAFT_PART_INSTALL}/usr/bin/alertmanager
+        install -D -m755 bin/amtool ${CRAFT_PART_INSTALL}/usr/bin/amtool
     stage:
-      - bin/alertmanager
-      - bin/amtool
+      - usr/bin/alertmanager
+      - usr/bin/amtool
   default-config:
     plugin: dump
     source: .

--- a/rocks.just
+++ b/rocks.just
@@ -169,7 +169,11 @@ release-oci-factory version=latest_version support="minor" risk="stable":
   if [ ! -e {{version}}/*.rock ]; then echo "× Error: rock not found. Please run 'just pack {{version}}' first."; exit 2; fi
   repository="$(git remote get-url origin | sed -E 's#(git@[^:]+:|https?://[^/]+/)##; s/\.git$//')"
   # Extract the base from the rockcraft.yaml (e.g. "ubuntu@24.04" -> "24.04")
+  # For bare-based rocks, fall back to build-base (e.g. "ubuntu@26.04" -> "26.04")
   rock_base="$(yq -r '.base' "{{version}}/rockcraft.yaml" | sed 's/.*@//')"
+  if [[ "$rock_base" == "bare" ]]; then
+    rock_base="$(yq -r '.["build-base"]' "{{version}}/rockcraft.yaml" | sed 's/.*@//')"
+  fi
   echo "Detected base: $rock_base"
   # Clone the oci-factory and push data to it
   gh repo sync --force observability-noctua-bot/oci-factory

--- a/spread.yaml
+++ b/spread.yaml
@@ -25,9 +25,7 @@ suites:
       sudo snap install --classic rockcraft
 
       # Wait for docker daemon to come online
-      sudo apt install --yes retry
-      retry --times=10 --delay 2 -- docker run hello-world
-      sudo apt remove --yes retry
+      for i in $(seq 1 10); do docker info >/dev/null 2>&1 && break || sleep 2; done
 
       # Load the rock into docker
       sudo rockcraft.skopeo --insecure-policy copy "oci-archive:$CRAFT_ARTIFACT" docker-daemon:rockcraft-test:latest


### PR DESCRIPTION
Bump `base` from `ubuntu@24.04` to `ubuntu@26.04` for versions 0.31.1, 0.32.0, 0.32.1.